### PR TITLE
Add quotes around file paths

### DIFF
--- a/autoload/EasyGrep.vim
+++ b/autoload/EasyGrep.vim
@@ -172,7 +172,7 @@ endfunction
 "}}}
 " EscapeList/ShellEscapeList {{{
 function! EasyGrep#FileEscape(item)
-    return escape(a:item, ' \')
+    return '"'.escape(a:item, ' \').'"'
 endfunction
 function! EasyGrep#ShellEscape(item)
     return shellescape(a:item, 1)


### PR DESCRIPTION
Lets EasyGrep work with paths that have spaces in them. Sorry if this is a stupid way to fix that, but it worked for me :)